### PR TITLE
Trappl/be creator contributor organizational

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nr-oaipmh-harvesters
-version = 1.0.6
+version = 1.0.7
 description = OAIPMH harvesters for National repository
 authors = ["Alzbeta Pokorna <alzbeta.pokorna@cesnet.cz>", "Miroslav Simek <miroslav.simek@cesnet.cz>"]
 readme = README.md


### PR DESCRIPTION
- implemented new heuristic to determine whether a contributor may be personal name type or organizational

rules are the following:

1. direct match with institutions vocabularies means organizational
2. its personal when the string contains an acadamic title
3. its organizational if it contains an organizational hypernym (e.g. 'Univerzit..')
4. its orginazaitonal if it contains an company ending (e.g. s.r.o.)

the last rule was a bit tricky because there are creators/contributors strings containing a person with a company. after oral agreement, we treat them as personal and we think of the company as an affiliation (possibly implemented in the future). this is resolved by prioritizing 2. rule before 4.