### PR TITLE
Trappl/be 260 fix nr oaipmh harvester contributor transformation

### DIFF
--- a/nr_oaipmh_harvesters/nusl/transformer.py
+++ b/nr_oaipmh_harvesters/nusl/transformer.py
@@ -410,7 +410,7 @@ def transform_720_contributor(md, entry, value):
                 value[0],
                 # type of the contributor - only person supported by now
                 "nameType",
-                resolve_name_type(value),
+                resolve_name_type(value[0]),
                 # role of the contributor
                 "role",
                 role,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nr-oaipmh-harvesters
-version = 1.0.8
+version = 1.0.9
 description = OAIPMH harvesters for National repository
 authors = ["Alzbeta Pokorna <alzbeta.pokorna@cesnet.cz>", "Miroslav Simek <miroslav.simek@cesnet.cz>"]
 readme = README.md


### PR DESCRIPTION
- in previous feature - distinguishing between personal and organizational type - i made a mistake by passing a tuple to resolve function instead of just the contributor string
    - this is a fix for this issue