### PR TITLE
Trappl/be 270 nr oaipmh harvesters fix contributor field and filter null

### DIFF
--- a/nr_oaipmh_harvesters/nusl/transformer.py
+++ b/nr_oaipmh_harvesters/nusl/transformer.py
@@ -412,7 +412,7 @@ def transform_720_contributor(md, entry, value):
                 "nameType",
                 resolve_name_type(value[0]),
                 # role of the contributor
-                "role",
+                "contributorType",
                 role,
             )
         )

--- a/nr_oaipmh_harvesters/nusl/transformer.py
+++ b/nr_oaipmh_harvesters/nusl/transformer.py
@@ -203,17 +203,23 @@ def transform_245_title(md, entry, value):
 
 @matches("24500b")
 def transform_245_translated_title(md, entry, value):
+    if value is None:
+        return
+    
     md.setdefault("additionalTitles", []).append(
         {"title": {"lang": "en", "value": value}, "titleType": "translatedTitle"}
     )
 
 
 @matches("24630n", "24630p")
-def transform_246_title_alternate(md, entry, val):
+def transform_246_title_alternate(md, entry, val):    
     _transform_title(md, entry, "alternativeTitle", val)
 
 
 def _transform_title(md, entry, titleType, val):
+    if val is None:
+        return
+    
     try:
         lang = get_alpha2_lang(entry.entry.get("04107a"))
         md.setdefault("additionalTitles", []).append(
@@ -236,6 +242,9 @@ def transform_24633a_subtitle(md, entry, val):
 
 @matches("24633b")
 def transform_24633b_subtitle(md, entry, val):
+    if val is None:
+        return
+    
     md.setdefault("additionalTitles", []).append(
         {"title": {"lang": "en", "value": val}, "titleType": "subtitle"}
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nr-oaipmh-harvesters
-version = 1.0.11
+version = 1.0.12
 description = OAIPMH harvesters for National repository
 authors = ["Alzbeta Pokorna <alzbeta.pokorna@cesnet.cz>", "Miroslav Simek <miroslav.simek@cesnet.cz>"]
 readme = README.md


### PR DESCRIPTION
- contributor role has been renamed to contributorType in the model
- marcxml parsing is perhaps not deterministic, we need to add check to forbid null values propagation